### PR TITLE
Add French localization for Rail Signal Planner

### DIFF
--- a/mods/RailSignalPlanner/locale/en/locale.cfg
+++ b/mods/RailSignalPlanner/locale/en/locale.cfg
@@ -32,7 +32,7 @@ place-signals-with-rail-planner-tooltip=Place signals as you are building rails.
 force-unidirectional=One-way rails only
 force-unidirectional-tooltip=Give an error if a bidirectional rail is attempted to be placed.\nThis improves performance slightly and does not mark ambiguous rails as bidirectional.\nWill not build signals on rail lines without signals.__1__
 force-build-rails=Build rails even if directions conflict
-force-build-rails-tooltip=When disabled rails are not allowed to be build when there is a conflict in rail directions. Can still use ghosts/bots to build it.\nWhen enabled rails will be placed even if the rail direction is inconsistent (vanilla behaviour), also disables the error message you get when doing so. In both cases no signals will be placed if the rail direction are conflicting.__1__
+force-build-rails-tooltip=When disabled, rails are not allowed to be build when there is a conflict in rail directions. Can still use ghosts/bots to build it.\nWhen enabled, rails will be placed even if the rail direction is inconsistent (vanilla behaviour), also disables the error message you get when doing so. In both cases no signals will be placed if the rail direction are conflicting.__1__
 
 [controls]
 rsp-custom-control= (__1__)

--- a/mods/RailSignalPlanner/locale/fr/locale.cfg
+++ b/mods/RailSignalPlanner/locale/fr/locale.cfg
@@ -1,0 +1,48 @@
+[rail-signal-tool]
+not-a-valid-entity=__1__ n'est pas un __2__ valide
+not-an-item=__1__ n'est pas un objet
+cant-place=__1__ ne peut pas être placé
+
+conflicting-directions=Impossible de connecter des rails avec des directions différentes
+not-unidirectional=Impossible de placer des rails qui créent des rails bidirectionnels
+
+[item-name]
+rail-signal-planner=Planificateur de signaux ferroviaires
+
+[item-description]
+rail-signal-planner=Place des signaux ferroviaires et des signaux de chaîne ferroviaire sur les rails et les intersections.
+rsp-regular-behaviour=__1__ et glisser pour placer des signaux sur les rails.
+rsp-alt-behaviour=__1__ pour inverser le paramètre "__2__".
+rsp-cancel-construction-jobs=__1__ et glisser pour annuler les travaux de construction.
+rsp-drag-to-deconstruct=__1__ et glisser pour déconstruire les signaux.
+
+[rsp-gui]
+rail-signal-planner=Planificateur de signaux ferroviaires
+rsp-menu-button-tooltip=Paramètres du planificateur de signaux ferroviaires
+tooltip-rail-signal=Signal ferroviaire - l'entité de signal ferroviaire à utiliser
+tooltip-rail-chain-signal=Signal de chaîne ferroviaire - l'entité de signal de chaîne ferroviaire à utiliser
+tooltip-wagon-length=Nombre de locomotives et de wagons de votre train le plus long
+wagon-length-label=Longueur du train (#locos + #wagons)
+tooltip-train-length=Longueur de votre train en tuiles - calculée automatiquement lorsque vous fournissez une longueur de wagon
+train-length-label=Longueur du train (tuiles)
+tooltip-rail-distance=Distance à laquelle les signaux ferroviaires sont séparés sur de longues distances
+rail-distance-label=Distance entre les signaux ferroviaires (tuiles)
+place-signals-with-rail-planner=Placer des signaux tout en construisant des rails
+place-signals-with-rail-planner-tooltip=Placez des signaux pendant que vous construisez des rails.\nLes signaux sont pris/placés dans l'inventaire lorsqu'ils sont à portée, sinon des fantômes/mises à niveau/déconstructions sont utilisés.\nNe fonctionne pas avec des rails fantômes.\nFonctionne avec des signaux fantômes, cependant, il ne prend pas en compte les signaux fantômes lors de la décision des rails à inclure dans le calcul, donc les réseaux ferroviaires sans ou avec seulement des signaux fantômes sont lourds en termes de performance.__1__
+force-unidirectional=Rails à sens unique uniquement
+force-unidirectional-tooltip=Donne une erreur si un rail bidirectionnel est tenté d'être placé.\nCela améliore légèrement les performances et ne marque pas les rails ambigus comme bidirectionnels.\nNe construira pas de signaux sur les lignes de rails sans signaux.__1__
+force-build-rails=Construire des rails même si les directions sont en conflit
+force-build-rails-tooltip=Lorsque désactivé, les rails ne sont pas autorisés à être construits lorsqu'il y a un conflit dans les directions des rails. Vous pouvez toujours utiliser des fantômes/robots pour les construire.\nLorsque activé, les rails seront placés même si la direction des rails est incohérente (comportement par défaut), et désactive également le message d'erreur que vous recevez dans ce cas. Dans les deux cas, aucun signal ne sera placé si les directions des rails sont en conflit.__1__
+
+[controls]
+rsp-custom-control= (__1__)
+give-rail-signal-planner=Créer un nouveau planificateur de signaux ferroviaires
+rsp-open-menu=Ouvrir ou fermer le menu
+rsp-toggle-place-signals-with-planner=Activer/désactiver la pose de signaux lors de la construction de rails
+rsp-toggle-unidirectional=Activer/désactiver les rails à sens unique
+
+[mod-setting-name]
+rsp-toggle-menu-icon=Activer le bouton des paramètres
+
+[mod-setting-description]
+rsp-toggle-menu-icon=Supprimer le bouton des paramètres du menu en haut à gauche. Les paramètres peuvent être ouverts en réactivant ce menu ou en cliquant avec le bouton droit sur l'élément planificateur de signaux ferroviaires dans l'inventaire.


### PR DESCRIPTION
Add French localization for Rail Signal Planner and added commas to force-build-rails-tooltip in english local for better legibility.

Wasn't quite sure what \_\_1\__ and \_\_2\_\_ are replaced by so I ran with what seemed best in the context