### PR TITLE
Better visualizations on pipes

### DIFF
--- a/mods/alt-alt-mode/locale/en/locale.cfg
+++ b/mods/alt-alt-mode/locale/en/locale.cfg
@@ -6,6 +6,7 @@ alt-alt-turn-off-completely=Turn off regular alt-mode completely
 alt-alt-show-quality-badge=Display quality badge
 alt-alt-show-quality-background=Use quality colour for icon backgrounds
 alt-alt-blacklist=Blacklisted entity types
+alt-alt-show-pipe-amount=Show fluid amount and temperature on pipes
 
 
 [mod-setting-description]
@@ -16,6 +17,7 @@ alt-alt-turn-off-completely=If false, pressing alt toggles between off, alternat
 alt-alt-show-quality-badge=Display the quality icon at the bottom left of items, recipes and signals
 alt-alt-show-quality-background=Colour the background of items, recipes and signals the colour of the quality. Otherwise, black.
 alt-alt-blacklist=List of entity types not to draw information on, comma separated. You can find the type of an entity in the prototype explorer by pressing __CONTROL__open-prototypes-gui__ or by hovering over the entity and pressing __CONTROL__open-prototype-explorer-gui__. \nThere is currently (Factorio 2.0.28) a bug where the sprite does not follow robots properly, so this is off by default. See FFF-421 and forum topic 125393.\n'simple-entity' refers to rocks and ruins in the base game.
+alt-alt-show-pipe-amount=Whether to show numbers next to the icon. Only affects pipes.
 
 [controls]
 alt-alt-increase-radius=Increase the radius of alternative alt-mode

--- a/mods/alt-alt-mode/scripts/constants.lua
+++ b/mods/alt-alt-mode/scripts/constants.lua
@@ -7,6 +7,6 @@
 return {
   update_interval = 60,
   min_scale = 0.45,
-  max_scale = 1,
+  max_scale = 3,
   max_size = 4
 }

--- a/mods/alt-alt-mode/settings.lua
+++ b/mods/alt-alt-mode/settings.lua
@@ -46,6 +46,13 @@ data:extend(
             default_value = true,
             order         = "alt-alt-b-b[background]",
           },
+          {
+            type          = "bool-setting",
+            name          = "alt-alt-show-pipe-amount",
+            setting_type  = "runtime-per-user",
+            default_value = true,
+            order         = "alt-alt-b-c[pipe]",
+          },
 
         }
 )


### PR DESCRIPTION
Improved visualizations on pipes to be more consistent
Old:
![Old](https://github.com/user-attachments/assets/4e8ec4ff-ac6b-46d6-af03-a8d1b10530de)

New:
![New](https://github.com/user-attachments/assets/bd65ab4c-2b8b-4353-9949-338af6186326)


Also added an option to disable showing fluid amount on pipes